### PR TITLE
Escape file paths

### DIFF
--- a/root/usr/local/bin/togo
+++ b/root/usr/local/bin/togo
@@ -396,11 +396,12 @@ class Package(SQLObject):
                     if (flag.name == "EXCLUDE"):
                         write_string = None
                     else:
-                        write_string = "%s %s" % (flag.name, file.path)
+                        write_string = "%s %s" % (flag.name, '"' + file.path)
                         if (flag.name == "%doc"):
                             write_string += ".gz"
+                        write_string += '"'
             else:
-                write_string = file.path
+                write_string = '"' + file.path '"'
                 
             if (write_string):
                 files.append(write_string)


### PR DESCRIPTION
When generating RPMs that contain spaces in the packaged filenames, rpmbuild will fail. This is a blunt attempt to fix this, it at least fixes my specific, current problem. A more robust escape mechanism like pipes.quote() could be used as well.