### PR TITLE
Ensure that the changelog file contains a valid date

### DIFF
--- a/root/usr/local/bin/togo
+++ b/root/usr/local/bin/togo
@@ -15,6 +15,9 @@ except ImportError:
 
 DEBUG=True
 
+# Ensure 'date' uses english names for months etc.
+os.environ['LC_ALL'] = "C"
+
 # Configure logger
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 log = logging.getLogger()


### PR DESCRIPTION
I'm using an Ubuntu with german date formats, eg. 12. Mär 2015.
rpmbuild is unable to handle this format and will exit with an error code.
Exporting LC_ALL=C at the beginning of this script will fix it.