### PR TITLE
Remove dependency on RPM python-sqlobject fail. The main program fail…

### DIFF
--- a/build-togo.sh
+++ b/build-togo.sh
@@ -4,13 +4,13 @@ echo
 echo "Checking build dependencies..."
 echo
 
-rpm -q rpm-build python-sqlobject
+rpm -q rpm-build 
 
 if [ $? -ne 0 ]; then
 	echo
 	echo "ERROR: Build dependencies not met."
 	echo
-	echo "  Please ensure that the 'rpm-build' and 'python-sqlobject' rpms"
+	echo "  Please ensure that 'rpm-build' and 'python-sqlobject'"
 	echo "  are installed before building."
 	echo
 	echo "  If you have satisfied these requirements via some other means"

--- a/spec/header
+++ b/spec/header
@@ -31,7 +31,7 @@ Source0: %{name}.tar.gz
 
 # If this package has prerequisites, uncomment this line and
 #  list them here - examples are already listed
-Requires: bash, python >= 2.5, python-sqlobject, rpm-build, rsync
+Requires: bash, python >= 2.5, rpm-build, rsync
 
 # A more verbose description of your package
 %description


### PR DESCRIPTION
…s if the python module is unavailable, which is probably ideally installed using `pip` rather than a local rpm package.