### PR TITLE
- Changed the gpg_name field to use the PREFERENCE_* variables so that

### DIFF
--- a/root/usr/bin/togo
+++ b/root/usr/bin/togo
@@ -847,7 +847,7 @@ class Package(SQLObject):
         fd.write(r"%_gpg_path      ~/.gnupg")
         fd.write("\n")
         fd.write(r"%_gpg_name      ")
-        fd.write(identity + '@' + hostname)
+        fd.write(PREFERENCE_NAME +" <"+ PREFERENCE_EMAIL + ">")
         fd.write('\n')
         fd.write("%_gpgbin        /usr/bin/gpg")
         if (disable_dependency_generation):


### PR DESCRIPTION
  togo can be used based on the configured identity rather than based
  on the current username and hostname